### PR TITLE
small patch to github plugin

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/python/black
-    rev: 23.3.0
+    rev: 23.7.0
     hooks:
       - id: black
         exclude: ^cookiecutter/
@@ -17,7 +17,7 @@ repos:
       - id: mixed-line-ending
         args: ["--fix=lf"]
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.0.277
+    rev: v0.0.278
     hooks:
       - id: ruff
         exclude: ^cookiecutter/

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -47,6 +47,10 @@ for url_str in pkg_meta["project_url"]:
     name, url = url_str.split(", ")
     urls[name] = url
 
+html_baseurl = os.environ.get(
+    "READTHEDOCS_CANONICAL_URL", "https://2bndy5.github.io/sphinx-social-cards/"
+)
+
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
@@ -83,7 +87,7 @@ today = time.strftime(time_fmt, time.localtime())
 # -- Options for sphinx_social_cards ------------------------------------------
 social_cards = {
     "description": pkg_meta["summary"],
-    "site_url": urls["Documentation"],
+    "site_url": html_baseurl,
 }
 
 # -- Options for autodoc -----------------------------------------------------
@@ -144,6 +148,7 @@ html_theme_options = {
     },
     "repo_url": urls["Source"],
     "repo_name": "Sphinx-Social-Cards",
+    "site_url": html_baseurl,
     "edit_uri": "blob/main/docs",
     "features": [
         "navigation.expand",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,10 @@ version_scheme= "no-guess-dev"
 local_scheme = "no-local-version"
 fallback_version = "0.0.0"
 
+[tool.ruff]
+# Decrease the maximum line length to 100 characters. (mostly for unbreakable docstrings)
+line-length = 100
+
 [tool.mypy]
 show_error_codes = true
 show_column_numbers = true

--- a/src/sphinx_social_cards/plugins/github/__init__.py
+++ b/src/sphinx_social_cards/plugins/github/__init__.py
@@ -74,12 +74,13 @@ or using the ``sphinx-social-cards`` package's optional dependency:
            OS used:
 
            - On Windows:
-             ``%LOCALAPPDATA%\\2bndy5\\sphinx-social-cards\\Cache\\<month> <day>
-             <year>``
-           - On Linux: ``/home/$(whoami)/.cache/sphinx-social-cards/<month> <day>
-             <year>``
-           - On MacOS: ``/Users/$(id -un)/Library/Caches/sphinx-social-cards/<month>
+             ``%LOCALAPPDATA%\\2bndy5\\sphinx_social_cards.plugins.github\\Cache\\<month>
              <day> <year>``
+           - On Linux:
+             ``/home/$(whoami)/.cache/sphinx_social_cards.plugins.github/<month> <day> <year>``
+           - On MacOS:
+             ``/Users/$(id -un)/Library/Caches/sphinx_social_cards.plugins.github/<month> <day>
+             <year>``
 """
 from pathlib import Path
 from typing import Tuple

--- a/src/sphinx_social_cards/plugins/github/context.py
+++ b/src/sphinx_social_cards/plugins/github/context.py
@@ -196,11 +196,14 @@ def get_context_github(owner: Optional[str], repo: Optional[str]) -> Dict[str, A
         LOGGER.info("Fetching info for github context about repo: %s/%s", owner, repo)
         res_json = try_request(f"https://api.github.com/repos/{owner}/{repo}").json()
         res_json = cast(Dict[str, Any], res_json)
+        license_name = ""
+        if isinstance(res_json.get("license", None), dict):
+            license_name = res_json.get("license", {}).get("name", "")
         gh_ctx.repo = Repo(
             stars=reduce_big_number(res_json.get("stargazers_count", 0)),
             watchers=reduce_big_number(res_json.get("watchers_count", 0)),
             forks=reduce_big_number(res_json.get("forks", 0)),
-            license=res_json.get("license", {}).get("name", ""),
+            license=license_name,
             open_issues=reduce_big_number(res_json.get("open_issues_count", 0)),
             topics=res_json.get("topics", []),
             name=res_json.get("name", ""),

--- a/src/sphinx_social_cards/plugins/github/utils.py
+++ b/src/sphinx_social_cards/plugins/github/utils.py
@@ -46,7 +46,7 @@ def get_cache_dir() -> str:
     today = time.strftime(time_fmt, time.localtime())
     cache_dir = Path(
         user_cache_dir(
-            "sphinx_social_cards.plugins.vcs", "2bndy5", version=today  # (1)!
+            "sphinx_social_cards.plugins.github", "2bndy5", version=today  # (1)!
         )
     )
     if cache_dir.parent.exists() and not cache_dir.exists():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,7 +20,7 @@ extensions = ["sphinx_social_cards"]
 html_logo = "images/message.png"
 # -- Options for sphinx_social_cards
 social_cards = {
-    "site_url": "https://github.com/2bndy5/sphinx-social-cards",
+    "site_url": "https://2bndy5.github.io/sphinx-social-cards",
     "description": "Generate social media preview cards for your sphinx documentation.",
 }
 """


### PR DESCRIPTION
- fix bug where license is not specified in REST API response payload
- update cache directory name (was still using old dev name) and related docs

## Other changes

- update pre-commit hooks' versions
- relax ruff's max line length to allow 100 chars