### PR TITLE
Fix build script

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from pathlib import Path
 import subprocess
 import shutil
 from typing import List, Dict, Any
-from urllib.request import Request, urlopen
+from urllib.request import Request, urlopen, HTTPError
 from setuptools import setup, Command
 from setuptools.command.build import SubCommand
 from setuptools.command.build_py import build_py
@@ -30,7 +30,7 @@ def download_fonts(font_id: str, font_cache: Path):
     """
     header = {
         # needed to avoid response 403
-        "User-Agent": ("Mozilla/5.0 (X11; U; Linux i686) Gecko/20071127 Firefox/2.0.0.11"),
+        "User-Agent": "Mozilla/5.0 (X11; U; Linux i686) Gecko/20071127 Firefox/2.0.0.11",
     }
     with urlopen(
         Request(f"https://api.fontsource.org/v1/fonts/{font_id}", headers=header)
@@ -40,7 +40,6 @@ def download_fonts(font_id: str, font_cache: Path):
     family = data["family"]
     # cache the font info
     info_cache = Path(font_cache, family).with_suffix(".json")
-    info_cache.write_text(json.dumps(data, indent=2), encoding="utf-8")
 
     # get all weights from default subset of normal style in TTF format
     assert "weights" in data and data["weights"]
@@ -49,20 +48,36 @@ def download_fonts(font_id: str, font_cache: Path):
     subset = data["defSubset"]
     assert "variants" in data
     assert "styles" in data
-    for weight in weights:
+    for i, weight in enumerate(weights):
         assert str(weight) in data["variants"]
+        does_weight_exist = True
         for style in data["styles"]:
+            if not does_weight_exist:
+                break
             assert style in data["variants"][str(weight)]
             assert subset in data["variants"][str(weight)][style]
             assert "url" in data["variants"][str(weight)][style][subset]
             assert "ttf" in data["variants"][str(weight)][style][subset]["url"]
             ttf_url: str = data["variants"][str(weight)][style][subset]["url"]["ttf"]
-            with urlopen(Request(ttf_url, headers=header)) as font:
-                ttf = font.read()
-                # cache ttf font
-                font_file_name = f"{family} {style} ({subset} {weight})"
-                ttf_cache = Path(font_cache, font_file_name).with_suffix(".ttf")
-                ttf_cache.write_bytes(ttf)
+            try:
+                with urlopen(Request(ttf_url, headers=header)) as font:
+                    ttf = font.read()
+                    # cache ttf font
+                    font_file_name = f"{family} {style} ({subset} {weight})"
+                    ttf_cache = Path(font_cache, font_file_name).with_suffix(".ttf")
+                    ttf_cache.write_bytes(ttf)
+                print("Downloaded font", font_id, weight, style, subset)
+            except HTTPError as exc:
+                if exc.code != 500:
+                    # A 500 error from FontSource means that it couldn't find the desired font on
+                    # the server. This is likely caused by Google making breaking changes (without
+                    # notice because they reserve the right to do that) to the Robot fonts.
+                    raise exc
+                print(f"Failed to download font {font_id} {weight} {style} {subset}: {repr(exc)}")
+                does_weight_exist = False
+                del data["variants"][str(weight)]
+                del data["weights"][i]
+    info_cache.write_text(json.dumps(data, indent=2), encoding="utf-8")
 
 
 class SrcDistCommand(sdist):


### PR DESCRIPTION
Apparently, the Google Fonts devs reserve the right to make breaking changes to their fonts without notice. Thus, the FontSource API can suffer malformed metadata and is reliant on Google Fonts devs to address it upstream.

This fixes the build script to compensate for missing weights/styles of the Robot font's Latin subsets. The cached metadata for the Roboto fonts is updated accordingly when errors occur downloading the fonts' ttf files.