### PR TITLE
chore: limit CI triggers for flaky workflows and reduce CI runtime

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,8 +3,26 @@ name: Docs
 on:
   push:
     branches: [main]
+    paths:
+      - "**/*.py"
+      - "!cookiecutter/**"
+      - "src/sphinx_social_cards/**/*.yml"
+      - "docs/**"
+      - ".pre-commit-config.yaml"
+      - "uv.lock"
+      - "pyproject.toml"
+      - ".github/workflows/docs.yml"
   pull_request:
     branches: [main]
+    paths:
+      - "**/*.py"
+      - "!cookiecutter/**"
+      - "src/sphinx_social_cards/**/*.yml"
+      - "docs/**"
+      - ".pre-commit-config.yaml"
+      - "uv.lock"
+      - "pyproject.toml"
+      - ".github/workflows/docs.yml"
   workflow_dispatch:
 
 permissions: {}
@@ -19,7 +37,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ['ubuntu-latest', 'windows-latest', 'macos-latest']
+        os: ["ubuntu-latest", "windows-latest", "macos-latest"]
     permissions:
       contents: read
     env:
@@ -37,7 +55,7 @@ jobs:
         uses: actions/setup-python@v6
         id: python-setup
         with:
-          python-version: '3.x'
+          python-version: "3.x"
       - name: Setup uv
         uses: astral-sh/setup-uv@b75a909f75acd358c2196fb9a5f1299a9a8868a4 # v6.7.0
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,8 +3,24 @@ name: Test
 on:
   push:
     branches: [main]
+    paths:
+      - "**/*.py"
+      - "!cookiecutter/**"
+      - "src/sphinx_social_cards/**/*.yml"
+      - ".pre-commit-config.yaml"
+      - "uv.lock"
+      - "pyproject.toml"
+      - ".github/workflows/test.yml"
   pull_request:
     branches: [main]
+    paths:
+      - "**/*.py"
+      - "!cookiecutter/**"
+      - "src/sphinx_social_cards/**/*.yml"
+      - ".pre-commit-config.yaml"
+      - "uv.lock"
+      - "pyproject.toml"
+      - ".github/workflows/test.yml"
 
 permissions: {}
 
@@ -18,8 +34,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ['ubuntu-latest', 'windows-latest', 'macos-latest']
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
+        os: ["ubuntu-latest", "windows-latest", "macos-latest"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     permissions:
       contents: read
     env:

--- a/cspell.config.yml
+++ b/cspell.config.yml
@@ -56,6 +56,7 @@ words:
   - pyobject
   - pypa
   - pypi
+  - pyproject
   - pyside
   - pytest
   - pyyaml

--- a/noxfile.py
+++ b/noxfile.py
@@ -99,7 +99,7 @@ def tests(session: nox.Session, sphinx: int):
 @nox.session
 def coverage(session: nox.Session):
     """Create coverage report."""
-    uv_sync(session, "--group", "test")
+    uv_sync(session, "--group", "coverage")
     session.run("coverage", "combine")
     total = int(session.run("coverage", "report", "--format=total", silent=True))
     session.run("coverage", "xml")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,9 +107,12 @@ docs = [
 ]
 test = [
     "appdirs>=1.4.4",
-    "coverage[toml]>=7.10.6",
     "pytest>=8.4.2",
     "sphinx-immaterial>=0.12.5",
     "sphinx[test]>=4.5",
     "standard-imghdr ; python_full_version >= '3.13'",
+    {include-group = "coverage"},
+]
+coverage = [
+    "coverage[toml]>=7.10.6",
 ]

--- a/setup.py
+++ b/setup.py
@@ -104,14 +104,15 @@ class BundleCommand(Command, SubCommand):
     def finalize_options(self):
         """Post-process options."""
         if self.dirty is None:
-            is_nox_session = os.environ.get("NOX_CURRENT_SESSION", "").startswith("tests-3.")
-            is_ci_building_dirty = os.environ.get("SPHINX_SOCIAL_CARDS_BUILD_DIRTY", "") == "true"
-            self.dirty = is_nox_session or is_ci_building_dirty
+            nox_session = os.environ.get("NOX_CURRENT_SESSION", "")
+            is_nox_session = nox_session.startswith("tests") or nox_session.startswith("docs")
+            self.dirty = is_nox_session
 
         if self.dirty:
             # NOTE: As of setuptools v64.0.2, we cannot raise an exception here for
             # editable installs.
-            if not Path(pkg_src, ".fonts").exists():
+            font_files = list(Path(pkg_src, ".fonts").glob("*.ttf"))
+            if not font_files:
                 self.dirty = False
                 return
 

--- a/uv.lock
+++ b/uv.lock
@@ -1393,6 +1393,9 @@ github = [
 ]
 
 [package.dev-dependencies]
+coverage = [
+    { name = "coverage", extra = ["toml"] },
+]
 dev = [
     { name = "docutils-stubs" },
     { name = "nox" },
@@ -1434,6 +1437,7 @@ requires-dist = [
 provides-extras = ["github"]
 
 [package.metadata.requires-dev]
+coverage = [{ name = "coverage", extras = ["toml"], specifier = ">=7.10.6" }]
 dev = [
     { name = "docutils-stubs", specifier = ">=0.0.22" },
     { name = "nox", specifier = ">=2025.5.1" },


### PR DESCRIPTION
a follow-up to #120

- limit CI triggers for flaky workflows. The docs and test workflows have sporadic SSL errors (mainly on windows runners) emitted from sphinx-immaterial docs' build.
- reduce CI runtime by building the pkg dirty during repeated `nox` sessions (`docs` and `tests`). Only applies when the downloaded default fonts do not exist.
- update uv.lock for all groups
